### PR TITLE
Add info logging if no loadbalancers are found

### DIFF
--- a/pkg/metrics/loadbalancer.go
+++ b/pkg/metrics/loadbalancer.go
@@ -56,6 +56,9 @@ func PublishLoadBalancerMetrics(client *gophercloud.ServiceClient, tenantID stri
 		klog.Warningf("Unable to extract load balancers: %v", err)
 		return err
 	}
+	if len(loadBalancerList) == 0 {
+		klog.Info("No load balancers found. Skipping load balancer metrics.")
+	}
 
 	// second step: reset the old metrics
 	loadbalancerAdminStateUp.Reset()


### PR DESCRIPTION
When working on #111 I didn't get the expected load balancer metrics. 

```
# HELP kos_loadbalancer_admin_state_up Load balancer admin state up
# TYPE kos_loadbalancer_admin_state_up gauge
# HELP kos_loadbalancer_provisioning_status Load balancer status
# TYPE kos_loadbalancer_provisioning_status gauge
```

After some investigation I noticed that the test project didn't actually have any load balancers in it and therefore no metrics where published. By adding this info log I hope that others might find this mistake faster than I did :sweat_smile: 