### PR TITLE
Update golangci-lint version (1.41.1 -> 1.50.0). Enable dupword linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - gofmt
     - goheader
     - govet
+    - dupword
 linters-settings:
   goheader:
     template: |

--- a/hack/check_golangci-lint.sh
+++ b/hack/check_golangci-lint.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-GOLANGCILINT_VERSION="1.41.1"
+GOLANGCILINT_VERSION="1.50.0"
 GOLANGCILINT_FILENAME="golangci-lint-${GOLANGCILINT_VERSION}-linux-amd64.tar.gz"
 GOLANGCILINT_URL="https://github.com/golangci/golangci-lint/releases/download/v${GOLANGCILINT_VERSION}/${GOLANGCILINT_FILENAME}"
 

--- a/pkg/metrics/cinder.go
+++ b/pkg/metrics/cinder.go
@@ -168,7 +168,7 @@ func publishVolumeMetrics(v volumes.Volume, pv *corev1.PersistentVolume) {
 	k8sMetadata := extractK8sMetadata(pv)
 
 	// add the k8s specific labels.
-	// We do not need need to check them, because the empty string is totally fine.
+	// We do not need to check them, because the empty string is totally fine.
 	labels = append(labels, k8sMetadata...)
 
 	// set the volume-specific metrics


### PR DESCRIPTION
While working on another pr I noticed a duplicate word `need need` in `cinder.go` so I removed it. To avoid this mistake in the future I upgraded golangci-lint and enabled the linter `dupword` which finds these type of errors.