### PR TITLE
fix(loadbalancer): prevent nil pointer deref by error handling

### DIFF
--- a/pkg/metrics/loadbalancer.go
+++ b/pkg/metrics/loadbalancer.go
@@ -99,12 +99,20 @@ func PublishLoadBalancerMetrics(client *gophercloud.ServiceClient, tenantID stri
 
 		// for the pools associated with the loadbalancer
 		for _, poolWithOnlyId := range lb.Pools {
-			pool, _ := pools.Get(client, poolWithOnlyId.ID).Extract()
+			pool, err := pools.Get(client, poolWithOnlyId.ID).Extract()
+			if err != nil {
+				klog.Warningf("Unable to get pool %s: %v", poolWithOnlyId.ID, err)
+				continue
+			}
 			publishPoolStatus(lb, *pool)
 
 			// for the pool members
 			for _, memberWithOnlyId := range pool.Members {
-				member, _ := pools.GetMember(client, pool.ID, memberWithOnlyId.ID).Extract()
+				member, err := pools.GetMember(client, pool.ID, memberWithOnlyId.ID).Extract()
+				if err != nil {
+					klog.Warningf("Unable to get member %s of pool %s: %v", memberWithOnlyId.ID, poolWithOnlyId.ID, err)
+					continue
+				}
 				publishMemberStatus(lb, *pool, *member)
 			}
 		}


### PR DESCRIPTION
Eventually the OpenStack API is overloaded and leads to Nil Pointer Dereference.
This PR introduces some error handling for failed calls.

The warning looks like this:
```
W0102 00:00:17.498806       1 loadbalancer.go:113] Unable to get member 16d09e83-acc5-48e3-a463-c2ebca55ccb4 of pool 2ff62d69-a61f-4d58-9858-477af1c7cb54: The service is currently unable to handle the request due to a temporary overloading or maintenance. This is a temporary condition. Try again later.
```