### PR TITLE
ci: move to ghcr.io and use GITHUB_TOKEN for registry auth

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -27,11 +27,11 @@ jobs:
         make all
     - name: generate changelog from git
       run: |
-        echo "Image is available at \`docker.pkg.github.com/mercedes-benz/kosmoo/kosmoo:$(git describe --tags --exact-match)\`." > ${{ github.workflow }}-CHANGELOG.txt
+        echo "Image is available at \`ghcr.io/mercedes-benz/kosmoo/kosmoo:$(git describe --tags --exact-match)\`." > ${{ github.workflow }}-CHANGELOG.txt
         git log --format=format:"* %h %s" $(git describe --tags --abbrev=0 @^)..@ >> ${{ github.workflow }}-CHANGELOG.txt
     - name: push to package registry
       run: |
-        docker login docker.pkg.github.com -u chrischdi -p "${PACKAGE_REPO_TOKEN}" 
+        echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $ --password-stdin
         make push
       env:
         PACKAGE_REPO_TOKEN: ${{ secrets.PACKAGE_REPO_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ VERSION ?= $(shell git describe --tags --exact-match || \
 
 SRCS = $(shell find . -type f -name '*.go' -not -path "./vendor/*")
 
-REGISTRY ?= docker.pkg.github.com/mercedes-benz/kosmoo
+REGISTRY ?= ghcr.io/mercedes-benz/kosmoo
 
 all: test build docker
 

--- a/kubernetes/base/deployment.yaml
+++ b/kubernetes/base/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       - args:
         - -refresh-interval=300
         - -cloud-conf=/etc/cloud.conf
-        image: docker.pkg.github.com/mercedes-benz/kosmoo/kosmoo:latest
+        image: ghcr.io/mercedes-benz/kosmoo/kosmoo:latest
         imagePullPolicy: Always
         name: exporter
         ports:

--- a/kubernetes/overlays/examples/kustomization.yaml
+++ b/kubernetes/overlays/examples/kustomization.yaml
@@ -4,6 +4,6 @@ kind: Kustomization
 bases:
 - ../../base
 images:
-- name: docker.pkg.github.com/mercedes-benz/kosmoo/kosmoo
+- name: ghcr.io/mercedes-benz/kosmoo/kosmoo
   newName: other/kosmoo
   newTag: new


### PR DESCRIPTION
Authenticating to ghcr.io according to https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions#upgrading-a-workflow-that-accesses-a-registry-using-a-personal-access-token.

This should fix our release action.